### PR TITLE
AttributeExp is reused in the Expressionpool and have to be immutable

### DIFF
--- a/msv/src/main/java/com/sun/msv/grammar/AttributeExp.java
+++ b/msv/src/main/java/com/sun/msv/grammar/AttributeExp.java
@@ -53,16 +53,23 @@ public class AttributeExp extends Expression implements NameClassAndExpression {
     public final Expression exp;
     public final Expression getContentModel() { return exp; }
 
-    protected String defaultValue;
+    public final String defaultValue;
 
     public AttributeExp( NameClass nameClass, Expression exp ) {
         super( nameClass.hashCode()+exp.hashCode() );
         this.nameClass    = nameClass;
         this.exp        = exp;
+        this.defaultValue = null;
+    }
+    
+    public AttributeExp( NameClass nameClass, Expression exp, String defaultValue ) {
+        super( nameClass.hashCode()^exp.hashCode() );
+        this.nameClass    = nameClass;
+        this.exp        = exp;
+        this.defaultValue = defaultValue;
     }
 
     public String getDefaultValue() { return defaultValue; }
-    public void setDefaultValue(String v) { defaultValue = v; }
 
     protected final int calcHashCode() {
         int hash = nameClass.hashCode()+exp.hashCode();

--- a/msv/src/main/java/com/sun/msv/grammar/ExpressionPool.java
+++ b/msv/src/main/java/com/sun/msv/grammar/ExpressionPool.java
@@ -78,8 +78,7 @@ public class ExpressionPool implements java.io.Serializable {
         if(content==Expression.nullSet) {
             return content;
         }
-        AttributeExp exp = new AttributeExp(nameClass,content);
-        exp.setDefaultValue(defaultValue);
+        AttributeExp exp = new AttributeExp(nameClass,content,defaultValue);
         return unify(exp);
     }
     


### PR DESCRIPTION
As AttributeExp is reused in the Expressionpool and have to be immutable, see https://github.com/xmlark/msv/blob/main/msv/src/main/java/com/sun/msv/grammar/Expression.java#L39

Therefore, 

1. no setter for the DefaultValue is allowed 
2. default value has to be set in the constructor 
3. the Defaultvalue String has to be final
