### PR TITLE
Replace deprecated constructors with static valueOf

### DIFF
--- a/generator/src/main/java/com/sun/msv/generator/Driver.java
+++ b/generator/src/main/java/com/sun/msv/generator/Driver.java
@@ -214,7 +214,7 @@ public class Driver {
 				opt.insertComment = false;
 			else
 			if( args[i].equalsIgnoreCase("-depth") )
-				opt.cutBackDepth = new Integer(args[++i]).intValue();
+				opt.cutBackDepth = Integer.valueOf(args[++i]).intValue();
 			else
 			if( args[i].equalsIgnoreCase("-example") ) {
                 String fileName = args[++i];
@@ -229,10 +229,10 @@ public class Driver {
                 }
 			} else
 			if( args[i].equalsIgnoreCase("-width") )
-				opt.width = new Rand.UniformRand( opt.random, new Integer(args[++i]).intValue() );
+				opt.width = new Rand.UniformRand( opt.random, Integer.valueOf(args[++i]).intValue() );
 			else
 			if( args[i].equalsIgnoreCase("-n") ) {
-				number = new Integer(args[++i]).intValue();
+				number = Integer.valueOf(args[++i]).intValue();
 				if( number<1 )	number=1;
 			}
 			else
@@ -251,7 +251,7 @@ public class Driver {
 				encoding = args[++i];
 			else
 			if( args[i].equalsIgnoreCase("-seed") )
-				opt.random.setSeed( new Long(args[++i]).longValue() );
+				opt.random.setSeed( Long.valueOf(args[++i]).longValue() );
 			else
 			if( args[i].equalsIgnoreCase("-nonvalidate") )	// secret option
 				validate = false;

--- a/msv/examples/xpathloc/XPathLocationTracker.java
+++ b/msv/examples/xpathloc/XPathLocationTracker.java
@@ -178,20 +178,20 @@ public class XPathLocationTracker extends XMLFilterImpl {
     
     
     /**
-     * Effectively the same as <pre>new Integer(i)</pre>
+     * Effectively the same as <pre>Integer.valueOf(i)</pre>
      */
     private static Integer getInt(int i) {
         if(i<ints.length)
             return ints[i];
         else
-            return new Integer(i);
+            return Integer.valueOf(i);
     }
     
     private static final Integer[] ints = new Integer[] {
-        new Integer(0),
-        new Integer(1),
-        new Integer(2),
-        new Integer(3),
-        new Integer(4)
+        Integer.valueOf(0),
+        Integer.valueOf(1),
+        Integer.valueOf(2),
+        Integer.valueOf(3),
+        Integer.valueOf(4)
     };
 }

--- a/msv/src/main/java/com/sun/msv/driver/textui/Driver.java
+++ b/msv/src/main/java/com/sun/msv/driver/textui/Driver.java
@@ -329,7 +329,7 @@ public class Driver {
 
         long parsingTime = System.currentTimeMillis();
         if( verbose )
-            System.out.println( localize( MSG_PARSING_TIME, new Long(parsingTime-stime) ) );
+            System.out.println( localize( MSG_PARSING_TIME, Long.valueOf(parsingTime-stime) ) );
 
 
         if(dump) {
@@ -405,7 +405,7 @@ public class Driver {
 
 
         if( verbose )
-            System.out.println( localize( MSG_VALIDATION_TIME, new Long(System.currentTimeMillis()-parsingTime) ) );
+            System.out.println( localize( MSG_VALIDATION_TIME, Long.valueOf(System.currentTimeMillis()-parsingTime) ) );
 
         return allValid?0:-1;
     }

--- a/msv/src/main/java/com/sun/msv/driver/textui/ReportErrorHandler.java
+++ b/msv/src/main/java/com/sun/msv/driver/textui/ReportErrorHandler.java
@@ -39,50 +39,50 @@ import com.sun.msv.verifier.ValidationUnrecoverableException;
 
 /**
  * {@link ErrorHandler} that reports all errors and warnings.
- * 
+ *
  * SAX parse errors are also handled.
- * 
+ *
  * @author <a href="mailto:kohsuke.kawaguchi@eng.sun.com">Kohsuke KAWAGUCHI</a>
  */
 public class ReportErrorHandler implements ErrorHandler {
-    
+
     private int counter = 0;
     public boolean hadError = false;
-    
+
     public void error( SAXParseException e ) throws SAXException {
         hadError = true;
         countCheck(e);
         printSAXParseException( e, MSG_ERROR );
     }
-    
+
     public void fatalError( SAXParseException e ) throws SAXException {
         hadError = true;
         printSAXParseException( e, MSG_FATAL );
         throw new ValidationUnrecoverableException(e);
     }
-    
+
     public void warning( SAXParseException e ) {
         printSAXParseException( e, MSG_WARNING );
     }
-    
+
     protected static void printSAXParseException( SAXParseException spe, String prop ) {
         System.out.println(
             Driver.localize( prop, new Object[]{
-                new Integer(spe.getLineNumber()), 
-                new Integer(spe.getColumnNumber()),
+                Integer.valueOf(spe.getLineNumber()),
+                Integer.valueOf(spe.getColumnNumber()),
                 spe.getSystemId(),
                 spe.getLocalizedMessage()} ) );
     }
-    
-    
+
+
     private void countCheck( SAXParseException e )
         throws ValidationUnrecoverableException    {
         if( counter++ < 20 )    return;
-        
+
         System.out.println( Driver.localize(MSG_TOO_MANY_ERRORS) );
         throw new ValidationUnrecoverableException(e);
     }
-    
+
     public static final String MSG_TOO_MANY_ERRORS = //arg:1
         "ReportErrorHandler.TooManyErrors";
     public static final String MSG_ERROR = // arg:4

--- a/msv/src/main/java/com/sun/msv/reader/trex/TREXSequencedStringChecker.java
+++ b/msv/src/main/java/com/sun/msv/reader/trex/TREXSequencedStringChecker.java
@@ -86,8 +86,8 @@ public class TREXSequencedStringChecker implements ExpressionVisitor
 
     /** integer pool implementation. */
     private static final Integer[] intPool = new Integer[]{
-            new Integer(0),new Integer(1),new Integer(2),new Integer(3),
-            new Integer(4),new Integer(5),new Integer(6),new Integer(7) };
+            Integer.valueOf(0),Integer.valueOf(1),Integer.valueOf(2),Integer.valueOf(3),
+            Integer.valueOf(4),Integer.valueOf(5),Integer.valueOf(6),Integer.valueOf(7) };
 
     // 3 bit of information
     private static final int HAS_ELEMENT = 4;

--- a/msv/src/main/java/com/sun/msv/reader/xmlschema/IdentityConstraintState.java
+++ b/msv/src/main/java/com/sun/msv/reader/xmlschema/IdentityConstraintState.java
@@ -156,9 +156,9 @@ public class IdentityConstraintState extends SimpleState {
                             XMLSchemaReader.ERR_KEY_FIELD_NUMBER_MISMATCH,
                             new Object[]{
                                 idc.localName,
-                                new Integer(idc.fields.length),
+                                Integer.valueOf(idc.fields.length),
                                 keyRef.localName,
-                                new Integer(keyRef.fields.length) } );
+                                Integer.valueOf(keyRef.fields.length) } );
                         return;
                     }
                     

--- a/msv/src/main/java/com/sun/msv/verifier/identity/FieldMatcher.java
+++ b/msv/src/main/java/com/sun/msv/verifier/identity/FieldMatcher.java
@@ -168,6 +168,6 @@ public class FieldMatcher extends PathMatcher {
             new Object[]{
                 parent.selector.idConst.namespaceURI,
                 parent.selector.idConst.localName,
-                new Integer(i+1)} );
+                Integer.valueOf(i+1)} );
     }
 }

--- a/msv/src/main/java/com/sun/msv/verifier/identity/FieldsMatcher.java
+++ b/msv/src/main/java/com/sun/msv/verifier/identity/FieldsMatcher.java
@@ -100,7 +100,7 @@ public class FieldsMatcher extends MatcherBundle {
                     new Object[]{
                         selector.idConst.namespaceURI,
                         selector.idConst.localName,
-                        new Integer(i+1)} );
+                        Integer.valueOf(i+1)} );
                 return;
             }
 

--- a/tahiti/src/main/java/com/sun/tahiti/compiler/ll/ExpressionSerializer.java
+++ b/tahiti/src/main/java/com/sun/tahiti/compiler/ll/ExpressionSerializer.java
@@ -156,7 +156,7 @@ class ExpressionSerializer {
 	public void assignId( Expression exp ) {
 		if( expr2id.containsKey(exp) )	throw new Error("assertion failed");
 			
-		expr2id.put( exp, new Integer(expr2id.size()) );
+		expr2id.put( exp, Integer.valueOf(expr2id.size()) );
 	}
 	
 	

--- a/tahiti/src/main/java/com/sun/tahiti/grammar/util/Multiplicity.java
+++ b/tahiti/src/main/java/com/sun/tahiti/grammar/util/Multiplicity.java
@@ -32,7 +32,7 @@ public class Multiplicity {
 		this.min = min; this.max = max;
 	}
 	public Multiplicity( int min, int max ) {
-		this.min = min; this.max = new Integer(max);
+		this.min = min; this.max = Integer.valueOf(max);
 	}
 	
 	/** returns true if the multiplicity is (1,1). */
@@ -78,13 +78,13 @@ public class Multiplicity {
 			Math.min(lhs.min,rhs.min),
 			(lhs.max==null||rhs.max==null)?
 				null:
-				new Integer(Math.max(lhs.max.intValue(),rhs.max.intValue())) );
+				Integer.valueOf(Math.max(lhs.max.intValue(),rhs.max.intValue())) );
 	}
 	public static Multiplicity group( Multiplicity lhs, Multiplicity rhs ) {
 		return new Multiplicity( lhs.min+rhs.min,
 			(lhs.max==null||rhs.max==null)?
 				null:
-				new Integer(lhs.max.intValue()+rhs.max.intValue()) );
+				Integer.valueOf(lhs.max.intValue()+rhs.max.intValue()) );
 	}
 	public static Multiplicity oneOrMore( Multiplicity c ) {
 		if(c.max==null)				return c; // (x,*) => (x,*)

--- a/xsdlib/src/main/java/com/sun/msv/datatype/xsd/ByteType.java
+++ b/xsdlib/src/main/java/com/sun/msv/datatype/xsd/ByteType.java
@@ -45,7 +45,7 @@ public class ByteType extends IntegerDerivedType {
     public final static ByteType theInstance = new ByteType();
     private ByteType() {
         super("byte",createRangeFacet(ShortType.theInstance,
-            new Byte(Byte.MIN_VALUE), new Byte(Byte.MAX_VALUE)));
+            Byte.valueOf(Byte.MIN_VALUE), Byte.valueOf(Byte.MAX_VALUE)));
     }
     
     final public XSDatatype getBaseType() {
@@ -59,7 +59,7 @@ public class ByteType extends IntegerDerivedType {
     public static Byte load( String s ) {
         // Implementation of JDK1.2.2/JDK1.3 is suitable enough
         try {
-            return new Byte(removeOptionalPlus(s));
+            return Byte.valueOf(removeOptionalPlus(s));
         } catch( NumberFormatException e ) {
             return null;
         }

--- a/xsdlib/src/main/java/com/sun/msv/datatype/xsd/DoubleType.java
+++ b/xsdlib/src/main/java/com/sun/msv/datatype/xsd/DoubleType.java
@@ -58,9 +58,9 @@ public class DoubleType extends FloatingNumberType {
     public static Double load( String lexicalValue ) {
         // TODO : probably the same problems exist as in the case of float
         try {
-            if(lexicalValue.equals("NaN"))    return new Double(Double.NaN);
-            if(lexicalValue.equals("INF"))    return new Double(Double.POSITIVE_INFINITY);
-            if(lexicalValue.equals("-INF"))    return new Double(Double.NEGATIVE_INFINITY);
+            if(lexicalValue.equals("NaN"))    return Double.valueOf(Double.NaN);
+            if(lexicalValue.equals("INF"))    return Double.valueOf(Double.POSITIVE_INFINITY);
+            if(lexicalValue.equals("-INF"))    return Double.valueOf(Double.NEGATIVE_INFINITY);
             
             if(lexicalValue.length()==0
             || !isDigitOrPeriodOrSign(lexicalValue.charAt(0))

--- a/xsdlib/src/main/java/com/sun/msv/datatype/xsd/FloatType.java
+++ b/xsdlib/src/main/java/com/sun/msv/datatype/xsd/FloatType.java
@@ -73,9 +73,9 @@ public class FloatType extends FloatingNumberType {
         */
         
         try {
-            if(s.equals("NaN"))        return new Float(Float.NaN);
-            if(s.equals("INF"))        return new Float(Float.POSITIVE_INFINITY);
-            if(s.equals("-INF"))    return new Float(Float.NEGATIVE_INFINITY);
+            if(s.equals("NaN"))        return Float.valueOf(Float.NaN);
+            if(s.equals("INF"))        return Float.valueOf(Float.POSITIVE_INFINITY);
+            if(s.equals("-INF"))    return Float.valueOf(Float.NEGATIVE_INFINITY);
             
             if(s.length()==0
             || !isDigitOrPeriodOrSign(s.charAt(0))

--- a/xsdlib/src/main/java/com/sun/msv/datatype/xsd/FractionDigitsFacet.java
+++ b/xsdlib/src/main/java/com/sun/msv/datatype/xsd/FractionDigitsFacet.java
@@ -71,7 +71,7 @@ public class FractionDigitsFacet extends DataTypeWithLexicalConstraintFacet {
         
         throw new DatatypeException( DatatypeException.UNKNOWN, 
             localize(ERR_TOO_MUCH_SCALE,
-            new Integer(cnt), new Integer(scale)) );
+            Integer.valueOf(cnt), Integer.valueOf(scale)) );
     }
     
     /** count the number of fractional digits.

--- a/xsdlib/src/main/java/com/sun/msv/datatype/xsd/IntType.java
+++ b/xsdlib/src/main/java/com/sun/msv/datatype/xsd/IntType.java
@@ -45,8 +45,8 @@ public class IntType extends IntegerDerivedType {
     
     public static final IntType theInstance =
         new IntType("int",createRangeFacet( LongType.theInstance,
-            new Integer(Integer.MIN_VALUE),
-            new Integer(Integer.MAX_VALUE)));
+            Integer.valueOf(Integer.MIN_VALUE),
+            Integer.valueOf(Integer.MAX_VALUE)));
     
     protected IntType(String typeName,XSDatatypeImpl baseFacets) {
         super(typeName,baseFacets);
@@ -63,7 +63,7 @@ public class IntType extends IntegerDerivedType {
     public static Integer load( String s ) {
         // Implementation of JDK1.2.2/JDK1.3 is suitable enough
         try {
-            return new Integer(removeOptionalPlus(s));
+            return Integer.valueOf(removeOptionalPlus(s));
         } catch( NumberFormatException e ) {
             return null;
         }

--- a/xsdlib/src/main/java/com/sun/msv/datatype/xsd/LengthFacet.java
+++ b/xsdlib/src/main/java/com/sun/msv/datatype/xsd/LengthFacet.java
@@ -82,7 +82,7 @@ public class LengthFacet extends DataTypeWithValueConstraintFacet {
         int cnt = ((Discrete)concreteType).countLength(o);
         if(cnt!=length)
             throw new DatatypeException( DatatypeException.UNKNOWN,
-                localize(ERR_LENGTH, new Integer(cnt), new Integer(length)) );
+                localize(ERR_LENGTH, Integer.valueOf(cnt), Integer.valueOf(length)) );
     }
 
     // serialization support

--- a/xsdlib/src/main/java/com/sun/msv/datatype/xsd/LongType.java
+++ b/xsdlib/src/main/java/com/sun/msv/datatype/xsd/LongType.java
@@ -45,8 +45,8 @@ public class LongType extends IntegerDerivedType {
     public static final LongType theInstance = new LongType();
     private LongType() {
         super("long",createRangeFacet( IntegerType.theInstance,
-            new Long(Long.MIN_VALUE),
-            new Long(Long.MAX_VALUE)));
+            Long.valueOf(Long.MIN_VALUE),
+            Long.valueOf(Long.MAX_VALUE)));
     }
     protected LongType( String typeName, XSDatatypeImpl baseFacets ) {
         super(typeName,baseFacets);
@@ -63,7 +63,7 @@ public class LongType extends IntegerDerivedType {
     public static Long load( String s ) {
         // Implementation of JDK1.2.2/JDK1.3 is suitable enough
         try {
-            return new Long(removeOptionalPlus(s));
+            return Long.valueOf(removeOptionalPlus(s));
         } catch( NumberFormatException e ) {
             return null;
         }

--- a/xsdlib/src/main/java/com/sun/msv/datatype/xsd/MaxLengthFacet.java
+++ b/xsdlib/src/main/java/com/sun/msv/datatype/xsd/MaxLengthFacet.java
@@ -80,7 +80,7 @@ public class MaxLengthFacet extends DataTypeWithValueConstraintFacet
         int cnt = ((Discrete)concreteType).countLength(o);
         if(cnt>maxLength)
             throw new DatatypeException( DatatypeException.UNKNOWN,
-                localize(ERR_MAXLENGTH, new Integer(cnt), new Integer(maxLength)) );
+                localize(ERR_MAXLENGTH, Integer.valueOf(cnt), Integer.valueOf(maxLength)) );
     }
 
     // serialization support

--- a/xsdlib/src/main/java/com/sun/msv/datatype/xsd/MinLengthFacet.java
+++ b/xsdlib/src/main/java/com/sun/msv/datatype/xsd/MinLengthFacet.java
@@ -79,7 +79,7 @@ public class MinLengthFacet extends DataTypeWithValueConstraintFacet {
         int cnt = ((Discrete)concreteType).countLength(o);
         if(cnt<minLength)
             throw new DatatypeException( DatatypeException.UNKNOWN,
-                localize(ERR_MINLENGTH,    new Integer(cnt), new Integer(minLength)) );
+                localize(ERR_MINLENGTH,    Integer.valueOf(cnt), Integer.valueOf(minLength)) );
     }
 
     // serialization support

--- a/xsdlib/src/main/java/com/sun/msv/datatype/xsd/ShortType.java
+++ b/xsdlib/src/main/java/com/sun/msv/datatype/xsd/ShortType.java
@@ -44,8 +44,8 @@ import org.relaxng.datatype.ValidationContext;
 public class ShortType extends IntegerDerivedType {
     public static final ShortType theInstance =
         new ShortType("short",createRangeFacet(IntType.theInstance,
-            new Short(Short.MIN_VALUE),
-            new Short(Short.MAX_VALUE)));
+            Short.valueOf(Short.MIN_VALUE),
+            Short.valueOf(Short.MAX_VALUE)));
     
     protected ShortType(String typeName,XSDatatypeImpl baseFacets) {
         super(typeName,baseFacets);
@@ -62,7 +62,7 @@ public class ShortType extends IntegerDerivedType {
     public static Short load( String s ) {
         // Implementation of JDK1.2.2/JDK1.3 is suitable enough
         try {
-            return new Short(removeOptionalPlus(s));
+            return Short.valueOf(removeOptionalPlus(s));
         } catch( NumberFormatException e ) {
             return null;
         }

--- a/xsdlib/src/main/java/com/sun/msv/datatype/xsd/TotalDigitsFacet.java
+++ b/xsdlib/src/main/java/com/sun/msv/datatype/xsd/TotalDigitsFacet.java
@@ -69,7 +69,7 @@ public class TotalDigitsFacet extends DataTypeWithLexicalConstraintFacet {
         if( cnt<=precision )    return;
         
         throw new DatatypeException( DatatypeException.UNKNOWN,
-            localize(ERR_TOO_MUCH_PRECISION, new Integer(cnt), new Integer(precision)) );
+            localize(ERR_TOO_MUCH_PRECISION, Integer.valueOf(cnt), Integer.valueOf(precision)) );
     }
     
     /** counts the number of digits */

--- a/xsdlib/src/main/java/com/sun/msv/datatype/xsd/UnsignedByteType.java
+++ b/xsdlib/src/main/java/com/sun/msv/datatype/xsd/UnsignedByteType.java
@@ -47,7 +47,7 @@ public class UnsignedByteType extends ShortType {
         super("unsignedByte",createRangeFacet(
             UnsignedShortType.theInstance,
             null,
-            new Short((short)255)));
+            Short.valueOf((short)255)));
     }
 
     /** upper bound value. this is the maximum possible valid value as an unsigned int */

--- a/xsdlib/src/main/java/com/sun/msv/datatype/xsd/UnsignedIntType.java
+++ b/xsdlib/src/main/java/com/sun/msv/datatype/xsd/UnsignedIntType.java
@@ -52,7 +52,7 @@ public class UnsignedIntType extends LongType {
         super("unsignedInt",createRangeFacet(
             UnsignedLongType.theInstance,
             null,
-            new Long(4294967295L)));
+            Long.valueOf(4294967295L)));
     }
     
     final public XSDatatype getBaseType() {

--- a/xsdlib/src/main/java/com/sun/msv/datatype/xsd/UnsignedShortType.java
+++ b/xsdlib/src/main/java/com/sun/msv/datatype/xsd/UnsignedShortType.java
@@ -51,7 +51,7 @@ public class UnsignedShortType extends IntType {
         super("unsignedShort",createRangeFacet(
             UnsignedIntType.theInstance,
             null,
-            new Integer(65535)));
+            Integer.valueOf(65535)));
     }
     
     public XSDatatype getBaseType() {

--- a/xsdlib/src/main/java/com/sun/msv/datatype/xsd/datetime/BigDateTimeValueType.java
+++ b/xsdlib/src/main/java/com/sun/msv/datatype/xsd/datetime/BigDateTimeValueType.java
@@ -127,7 +127,7 @@ public class BigDateTimeValueType implements IDateTimeValueType {
         int minute,
         BigDecimal second,
         java.util.TimeZone timeZone) {
-        this(year, new Integer(month), new Integer(day), new Integer(hour), new Integer(minute), second, timeZone);
+        this(year, Integer.valueOf(month), Integer.valueOf(day), Integer.valueOf(hour), Integer.valueOf(minute), second, timeZone);
     }
 
     public BigDateTimeValueType(
@@ -388,10 +388,10 @@ public class BigDateTimeValueType implements IDateTimeValueType {
             // set those fields blank which are not originally specified.
             return new BigDateTimeValueType(
                 this.year != null ? oyear : null,
-                this.month != null ? new Integer(omonth) : null,
-                this.day != null ? new Integer(oday.intValue()) : null,
-                this.hour != null ? new Integer(ohour) : null,
-                this.minute != null ? new Integer(ominute) : null,
+                this.month != null ? Integer.valueOf(omonth) : null,
+                this.day != null ? Integer.valueOf(oday.intValue()) : null,
+                this.hour != null ? Integer.valueOf(ohour) : null,
+                this.minute != null ? Integer.valueOf(ominute) : null,
                 this.second != null ? osecond : null,
                 this.zone);
         } else {
@@ -466,8 +466,8 @@ public class BigDateTimeValueType implements IDateTimeValueType {
     /*
         public static void main( String[] args )
         {
-            Object o1 = new BigDateTimeValueType( new BigInteger("2001"), new Integer(5), new Integer(1), null, null, null, null );
-            Object o2 = new BigDateTimeValueType( new BigInteger("2001"), new Integer(5), new Integer(1), null, null, null, null );
+            Object o1 = new BigDateTimeValueType( new BigInteger("2001"), Integer.valueOf(5), Integer.valueOf(1), null, null, null, null );
+            Object o2 = new BigDateTimeValueType( new BigInteger("2001"), Integer.valueOf(5), Integer.valueOf(1), null, null, null, null );
             
             System.out.println(o1.hashCode());
             System.out.println(o2.hashCode());
@@ -481,8 +481,8 @@ public class BigDateTimeValueType implements IDateTimeValueType {
     
         public static void main( String[] args )
         {
-            Object o1 = new BigDateTimeValueType( new BigInteger("1512"), new Integer(1), new Integer(4), null, null, null, TimeZone.create(-12*60) );
-            Object o2 = new BigDateTimeValueType( new BigInteger("1512"), new Integer(1), new Integer(5), null, null, null, TimeZone.create(+12*60) );
+            Object o1 = new BigDateTimeValueType( new BigInteger("1512"), Integer.valueOf(1), Integer.valueOf(4), null, null, null, TimeZone.create(-12*60) );
+            Object o2 = new BigDateTimeValueType( new BigInteger("1512"), Integer.valueOf(1), Integer.valueOf(5), null, null, null, TimeZone.create(+12*60) );
             
             System.out.println(o1.hashCode());
             System.out.println(o2.hashCode());

--- a/xsdlib/src/main/java/com/sun/msv/datatype/xsd/datetime/PreciseCalendarParser.java
+++ b/xsdlib/src/main/java/com/sun/msv/datatype/xsd/datetime/PreciseCalendarParser.java
@@ -85,19 +85,19 @@ public class PreciseCalendarParser extends AbstractCalendarParser {
     }
 
     protected void setMinutes(int i) {
-        minute = new Integer(i);
+        minute = Integer.valueOf(i);
     }
 
     protected void setHours(int i) {
-        hour = new Integer(i);
+        hour = Integer.valueOf(i);
     }
 
     protected void setDay(int i) {
-        day = new Integer(i-1);     // zero origin
+        day = Integer.valueOf(i-1);     // zero origin
     }
 
     protected void setMonth(int i) {
-        month = new Integer(i-1);   // zero origin
+        month = Integer.valueOf(i-1);   // zero origin
     }
 
     protected void setYear(int i) {

--- a/xsdlib/src/main/java/com/sun/msv/datatype/xsd/datetime/Util.java
+++ b/xsdlib/src/main/java/com/sun/msv/datatype/xsd/datetime/Util.java
@@ -56,7 +56,7 @@ class Util {
     protected static final BigInteger the210379680 = new BigInteger("210379680");
                                                                     
     protected static final BigDecimal decimal0 = new BigDecimal(BigInteger.ZERO,0);
-    protected static final Integer int0 = new Integer(0);
+    protected static final Integer int0 = Integer.valueOf(0);
                                                       
     protected static java.util.TimeZone timeZonePos14 = new SimpleTimeZone( 14*60*60*1000,"");
     protected static java.util.TimeZone timeZoneNeg14 = new SimpleTimeZone(-14*60*60*1000,"");

--- a/xsdlib/src/test/java/com/sun/msv/datatype/xsd/datetime/DateTimeFactoryTest.java
+++ b/xsdlib/src/test/java/com/sun/msv/datatype/xsd/datetime/DateTimeFactoryTest.java
@@ -37,7 +37,7 @@ public class DateTimeFactoryTest extends TestCase {
     {
         // 1 second
         IDateTimeValueType sec1 = DateTimeFactory.
-            createFromTime(null,null,new Integer(1000),null);
+            createFromTime(null,null,Integer.valueOf(1000),null);
         assertEquals( sec1,
                       new BigDateTimeValueType(null, null, null, null, null, new BigDecimal("1"), null ) );
     }

--- a/xsdlib/src/test/java/com/sun/msv/datatype/xsd/datetime/UtilTest.java
+++ b/xsdlib/src/test/java/com/sun/msv/datatype/xsd/datetime/UtilTest.java
@@ -56,17 +56,17 @@ public class UtilTest extends TestCase
     public void testObjCompare()
     {
         assertEquals( Comparator.EQUAL,        Util.objCompare(null,null) );
-        assertEquals( Comparator.LESS,        Util.objCompare(new Integer(10), new Integer(20)) );
-        assertEquals( Comparator.GREATER,    Util.objCompare(new Integer(25), new Integer(20)) );
-        assertEquals( Comparator.UNDECIDABLE,Util.objCompare(null,new Integer(1)) );
-        assertEquals( Comparator.UNDECIDABLE,Util.objCompare(new Integer(1),null) );
+        assertEquals( Comparator.LESS,        Util.objCompare(Integer.valueOf(10), Integer.valueOf(20)) );
+        assertEquals( Comparator.GREATER,    Util.objCompare(Integer.valueOf(25), Integer.valueOf(20)) );
+        assertEquals( Comparator.UNDECIDABLE,Util.objCompare(null,Integer.valueOf(1)) );
+        assertEquals( Comparator.UNDECIDABLE,Util.objCompare(Integer.valueOf(1),null) );
     }
     
     /** Test of int2bi method, of class com.sun.msv.datatype.datetime.Util. */
     public void testInt2bi()
     {
         assertEquals( Util.int2bi(15), new BigInteger("15") );
-        assertEquals( Util.int2bi(new Integer(15)), new BigInteger("15") );
+        assertEquals( Util.int2bi(Integer.valueOf(15)), new BigInteger("15") );
     }
     
     /** Test of maximumDayInMonthFor method, of class com.sun.msv.datatype.datetime.Util. */


### PR DESCRIPTION
Attempting a build with a newer JDK throws many warnings about deprecated functions.
https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Integer.html#%3Cinit%3E(int)