### PR TITLE
RangeToken - synchronize map creation

### DIFF
--- a/xsdlib/src/main/java/com/sun/msv/datatype/regexp/RangeToken.java
+++ b/xsdlib/src/main/java/com/sun/msv/datatype/regexp/RangeToken.java
@@ -70,6 +70,7 @@ final class RangeToken extends Token implements java.io.Serializable {
     RangeToken icaseCache = null;
     int[] map = null;
     int nonMapIndex;
+    volatile boolean mapCreated;
 
     RangeToken(int type) {
         super(type);
@@ -524,7 +525,7 @@ final class RangeToken extends Token implements java.io.Serializable {
     }
 
     boolean match(int ch) {
-        if (this.map == null)  this.createMap();
+        if (!this.mapCreated)  this.createMap();
         boolean ret;
         if (this.type == RANGE) {
             if (ch < MAPSIZE)
@@ -547,7 +548,8 @@ final class RangeToken extends Token implements java.io.Serializable {
     }
 
     private static final int MAPSIZE = 256;
-    private void createMap() {
+    private synchronized void createMap() {
+        if (this.mapCreated) return;
         int asize = MAPSIZE/32;                 // 32 is the number of bits in `int'.
         this.map = new int[asize];
         this.nonMapIndex = this.ranges.length;
@@ -567,6 +569,7 @@ final class RangeToken extends Token implements java.io.Serializable {
                 break;
             }
         }
+        this.mapCreated = true;
         //for (int i = 0;  i < asize;  i ++)  System.err.println("Map: "+Integer.toString(this.map[i], 16));
     }
 

--- a/xsdlib/src/test/java/com/sun/msv/datatype/regexp/RangeTokenTest.java
+++ b/xsdlib/src/test/java/com/sun/msv/datatype/regexp/RangeTokenTest.java
@@ -1,0 +1,73 @@
+package com.sun.msv.datatype.regexp;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * tests RangeToken.
+ *
+ * @author <a href="mailto:kirill.subbotin@tutanota.com">Kirill Subbotin</a>
+ */
+public class RangeTokenTest extends TestCase {
+
+    public RangeTokenTest( String name ) { super(name); }
+
+    public static void main(java.lang.String[] args) {
+        junit.textui.TestRunner.run(suite());
+    }
+
+    public static Test suite() {
+        return new TestSuite(RangeTokenTest.class);
+    }
+
+    public void testMatchUnderConcurrency() throws InterruptedException {
+        RangeToken rangeToken = new RangeToken(Token.RANGE);
+
+        rangeToken.addRange('<', '<');
+        rangeToken.addRange('=', '=');
+        rangeToken.addRange('>', '>');
+        rangeToken.addRange('?', '?');
+        rangeToken.addRange('@', '@');
+        rangeToken.addRange('A', 'A'); // our match
+        rangeToken.addRange('B', 'B');
+        rangeToken.addRange('C', 'C');
+        rangeToken.addRange('D', 'D');
+        rangeToken.addRange('E', 'E');
+        rangeToken.addRange('F', 'F');
+
+        int threads = Runtime.getRuntime().availableProcessors() * 4;
+        int runs =  threads * 1_000;
+
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+
+        try {
+            List<CompletableFuture<Boolean>> futures = new ArrayList<>();
+
+            for (int i = 0; i < runs; i++) {
+                futures.add(CompletableFuture.supplyAsync(
+                    () -> rangeToken.match('A'),
+                    executor
+                ));
+            }
+
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+            boolean allMatched = futures.stream()
+                .allMatch(CompletableFuture::join);
+
+            assertTrue(allMatched);
+        } finally {
+            executor.shutdown();
+            executor.awaitTermination(1, TimeUnit.MINUTES);
+        }
+    }
+
+}


### PR DESCRIPTION
In a highly parallelized environment we have found that the `RangeToken.match` may operate on a `RangeToken.map` that is actively being mutated by another process. 

The result: false negatives. 

I have included a test that under the right conditions should yield said false negatives. Now, it may take hundrets of attempts to achieve the desired outcome, which is why something akin to the following **local** adjustment to the tests main-method is advised.
```java
public static void main(java.lang.String[] args) {
    while (true) {
        junit.framework.TestResult result = junit.textui.TestRunner.run(suite());
        if (!result.wasSuccessful()) {
            break; // stop on first failure
        }
    }
}
```
Furthermore it may prove beneficial to restart if a false negative is not achieved within a minute or two of the infinite loop running. However, the latter is based on nothing more than anecdotal evidence.