### PR TITLE
Dependency Update: Replace old xml-resolver: with org.xmlresolver:xmlresolver

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -45,8 +45,8 @@
       <scope>test</scope>
     </dependency>
     <dependency><!-- for tests -->
-        <groupId>xml-resolver</groupId>
-        <artifactId>xml-resolver</artifactId>
+        <groupId>org.xmlresolver</groupId>
+        <artifactId>xmlresolver</artifactId>
         <optional>true</optional>
         <scope>test</scope>
     </dependency>

--- a/msv/examples/schemaLookup/Main.java
+++ b/msv/examples/schemaLookup/Main.java
@@ -14,11 +14,13 @@ import java.io.IOException;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import org.apache.xml.resolver.tools.CatalogResolver;
 import org.iso_relax.verifier.Schema;
 import org.iso_relax.verifier.Verifier;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
+import org.xmlresolver.ResourceResponse;
+import org.xmlresolver.XMLResolver;
+import org.xmlresolver.XMLResolverConfiguration;
 
 import com.sun.msv.driver.textui.DebugController;
 import com.sun.msv.grammar.Grammar;
@@ -63,19 +65,24 @@ public class Main {
 
     private static class SchemaBuilder implements NamespaceReceiver {
         
-        private final CatalogResolver resolver = new CatalogResolver();
+        private final XMLResolverConfiguration resolverConfig = new XMLResolverConfiguration();
+        private final XMLResolver resolver = new XMLResolver(resolverConfig);
         private final MultiSchemaReader msr = new MultiSchemaReader(
             new XMLSchemaReader(new DebugController(true)));
         
         public SchemaBuilder( String catalogFile ) throws IOException {
-            resolver.getCatalog().parseCatalog(catalogFile);
+            resolverConfig.addCatalog(new File(catalogFile).toURI().toString());
         }
         
         public void onNamespace(String ns) {
-            InputSource is = resolver.resolveEntity(ns,"");
-            if(is==null) {
+            ResourceResponse response = resolver.lookupUri(ns);
+            if(response==null || !response.isResolved() || response.getInputStream() == null) {
                 System.out.println("no schema found for the namespace "+ns);
                 return;
+            }
+            InputSource is = new InputSource(response.getInputStream());
+            if (response.getResolvedURI() != null) {
+                is.setSystemId(response.getResolvedURI().toString());
             }
             msr.parse(is);
         }

--- a/msv/pom.xml
+++ b/msv/pom.xml
@@ -69,8 +69,8 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
             <artifactId>relaxngDatatype</artifactId>
         </dependency>
         <dependency>
-            <groupId>xml-resolver</groupId>
-            <artifactId>xml-resolver</artifactId>
+            <groupId>org.xmlresolver</groupId>
+            <artifactId>xmlresolver</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/msv/src/main/java/com/sun/msv/driver/textui/Driver.java
+++ b/msv/src/main/java/com/sun/msv/driver/textui/Driver.java
@@ -40,10 +40,11 @@ import java.util.Locale;
 
 import javax.xml.parsers.SAXParserFactory;
 
-import org.apache.xml.resolver.tools.CatalogResolver;
 import org.iso_relax.dispatcher.Dispatcher;
 import org.iso_relax.dispatcher.SchemaProvider;
 import org.iso_relax.dispatcher.impl.DispatcherImpl;
+import org.xmlresolver.XMLResolver;
+import org.xmlresolver.XMLResolverConfiguration;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -177,6 +178,7 @@ public class Driver {
         boolean strict=false;
         boolean usePanicMode=true;
         EntityResolver entityResolver=null;
+        XMLResolverConfiguration resolverConfig = null;
 
         for( int i=0; i<args.length; i++ ) {
             args[i] = args[i].trim();
@@ -232,13 +234,13 @@ public class Driver {
             }
             else
             if( args[i].equalsIgnoreCase("-catalog") ) {
-                // use Sun's "XML Entity and URI Resolvers" by Norman Walsh
-                // to resolve external entities.
-                // http://www.sun.com/xml/developers/resolver/
-                if(entityResolver==null)
-                    entityResolver = new CatalogResolver(true);
-
-                ((CatalogResolver)entityResolver).getCatalog().parseCatalog(args[++i]);
+                // Resolve external entities through XML Resolver catalogs.
+                if (resolverConfig == null) {
+                    resolverConfig = new XMLResolverConfiguration();
+                    XMLResolver xmlResolver = new XMLResolver(resolverConfig);
+                    entityResolver = xmlResolver.getEntityResolver();
+                }
+                resolverConfig.addCatalog(new File(args[++i]).toURI().toString());
             }
             else
             if( args[i].equalsIgnoreCase("-version") || args[i].equalsIgnoreCase("-v")) {

--- a/msv/src/main/java/module-info.java
+++ b/msv/src/main/java/module-info.java
@@ -4,7 +4,7 @@ module net.java.dev.msv.core {
     requires net.java.dev.msv.xsdlib;
     requires isorelax;
     requires relaxngDatatype;
-    requires static xml.resolver;
+    requires static org.xmlresolver.xmlresolver;
 
     exports com.sun.msv.driver.textui;
     exports com.sun.msv.grammar;

--- a/msv/src/test/java/batch/BatchTester.java
+++ b/msv/src/test/java/batch/BatchTester.java
@@ -18,7 +18,8 @@ import javax.xml.parsers.SAXParserFactory;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
-import org.apache.xml.resolver.tools.CatalogResolver;
+import org.xml.sax.EntityResolver;
+import org.xmlresolver.XMLResolver;
 
 import batch.driver.DTDValidator;
 import batch.driver.GenericValidator;
@@ -46,7 +47,7 @@ import batch.model.TestReader;
 public abstract class BatchTester {
     public SAXParserFactory factory = SAXParserFactory.newInstance();
 
-    public CatalogResolver resolver = new CatalogResolver();
+    public EntityResolver resolver = new XMLResolver().getEntityResolver();
     
     /** schema file extension ".rlx", ".trex", or ".dtd" */
     public String ext;

--- a/msv/src/test/java/batch/driver/AbstractValidatorExImpl.java
+++ b/msv/src/test/java/batch/driver/AbstractValidatorExImpl.java
@@ -5,7 +5,7 @@ import java.io.InputStream;
 
 import javax.xml.parsers.SAXParserFactory;
 
-import org.apache.xml.resolver.tools.CatalogResolver;
+import org.xmlresolver.XMLResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
 
@@ -47,7 +47,7 @@ abstract class AbstractValidatorExImpl implements IValidatorEx
     static {
         factory.setNamespaceAware(true);
     }
-    private final static CatalogResolver resolver = new CatalogResolver();
+    private static final org.xml.sax.EntityResolver resolver = new XMLResolver().getEntityResolver();
     
     public boolean validate( Grammar grammar, File instance ) throws Exception {
         IVerifier verifier = getVerifier( grammar );

--- a/pom.xml
+++ b/pom.xml
@@ -119,9 +119,9 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
                 <scope>test</scope>
             </dependency>
             <dependency><!-- for tests -->
-                <groupId>xml-resolver</groupId>
-                <artifactId>xml-resolver</artifactId>
-                <version>1.2</version>
+                <groupId>org.xmlresolver</groupId>
+                <artifactId>xmlresolver</artifactId>
+                <version>6.0.21</version>
                 <optional>true</optional>
             </dependency>
             <!-- Test dependencies by xsdlib -->

--- a/rngconverter/pom.xml
+++ b/rngconverter/pom.xml
@@ -95,8 +95,8 @@ EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>xml-resolver</groupId>
-            <artifactId>xml-resolver</artifactId>
+            <groupId>org.xmlresolver</groupId>
+            <artifactId>xmlresolver</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This is the first replacement of the three old dependencies without Java modularisation:

1. isorelax-20030108.jar
2. relaxngDatatype-20020414.jar
3. xml-resolver-1.2.jar

The current compilation warning is:
[WARNING] * Required filename-based automodules detected: [xercesImpl-2.12.2.jar, isorelax-20030108.jar, relaxngDatatype-20020414.jar]. Please don't publish this project to a public artifact repository! *

Replace the legacy xml-resolver dependency with the current org.xmlresolver:xmlresolver artefact (latest 6.x on Maven Central). 
see https://github.com/xmlresolver/xmlresolver

The old Apache CatalogResolver API is no longer present on the new resolver, so update the TextUI catalogue option, batch test harness, and the schemaLookup example to use XMLResolver/XMLResolverConfiguration. Also, fixed module-info to require the correct automatic module name for JPMS builds (org.xmlresolver.xmlresolver instead of xml.resolver).


